### PR TITLE
Add github action to setup wl2 cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # wonderland2-setup-action
 A GitHub action to setup wl2 cli in your workflow
+
+## How to use
+
+Provide a github token with `repo` and `read:org` scopes and a valid ssh key for the same user.
+After the setup step, you can use the `wl2` cli as needed. The example shows a deployment.
+
+```yaml
+- name: Configure WL2
+  uses: Jimdo/wonderland2-setup-action@main
+  with:
+    wonderland-github-token: ${{ secrets.WONDERLAND_GITHUB_TOKEN }}
+    bastion-key: ${{ secrets.WONDERLAND_SSH_KEY }}
+
+- name: Deploy to Wonderland 2
+  run: wl2 deploy
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,35 @@
+name: 'Configure wl2 CLI'
+description: 'Configure the wl2 cli to interact with Wonderland 2'
+inputs:
+  wonderland-github-token:
+    description: 'A GitHub token with `repo` scope to download the wl2 cli'
+    required: true
+  bastion-key:
+    description: 'Ssh key for authentication in the bastion host'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ inputs.bastion-key }}
+        known_hosts: unnecessary
+
+    - uses: webfactory/ssh-agent@v0.5.4
+      with:
+        ssh-private-key: ${{ inputs.bastion-key }}
+
+    - run: |
+        asset_url=$(curl -s -H "Authorization: token ${{ inputs.wonderland-github-token }}" https://api.github.com/repos/Jimdo/wonderland2-cli/releases/latest | jq -r '.assets[] | select (.name=="wl2-linux-amd64").url')
+        curl -sSLfo /usr/local/bin/wl2 -H "Authorization: token ${{ inputs.wonderland-github-token }}" -H "Accept:application/octet-stream" $asset_url
+        chmod +x /usr/local/bin/wl2
+      shell: bash
+
+    - run: echo "WONDERLAND_GITHUB_TOKEN=${{ inputs.wonderland-github-token }}" >> $GITHUB_ENV
+      shell: bash
+
+    - run: |
+        wl2 version
+        wl2 kubectl version
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,9 @@ runs:
         ssh-private-key: ${{ inputs.bastion-key }}
 
     - run: |
-        asset_url=$(curl -s -H "Authorization: token ${{ inputs.wonderland-github-token }}" https://api.github.com/repos/Jimdo/wonderland2-cli/releases/latest | jq -r '.assets[] | select (.name=="wl2-linux-amd64").url')
+        asset_url=$(curl -s -H "Authorization: token ${{ inputs.wonderland-github-token }}"\
+                    https://api.github.com/repos/Jimdo/wonderland2-cli/releases/latest\
+                    | jq -r '.assets[] | select (.name=="wl2-linux-amd64").url')
         curl -sSLfo /usr/local/bin/wl2 -H "Authorization: token ${{ inputs.wonderland-github-token }}" -H "Accept:application/octet-stream" $asset_url
         chmod +x /usr/local/bin/wl2
       shell: bash
@@ -27,5 +29,4 @@ runs:
     - run: |
         wl2 version
         wl2 kubectl version
-        wl2 list
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ inputs.bastion-key }}
-        known_hosts: unnecessary
-
     - uses: webfactory/ssh-agent@v0.5.4
       with:
         ssh-private-key: ${{ inputs.bastion-key }}
@@ -32,4 +27,5 @@ runs:
     - run: |
         wl2 version
         wl2 kubectl version
+        wl2 list
       shell: bash


### PR DESCRIPTION
**What’s the idea:**
Instead of having a GitHub action to deploy the services, I decided to copy what other actions do with general purpose tools (configuring the aws client or docker for instance).
We now have a new GitHub action that configures SSH, sets the wonderland token in the environment and downloads the wl2 cli.
**What changes for our users:**
- They need to use a token with more privileges now on the CI (read:org  and repo) repo privileges are needed to be able to download the wl2 binary from the secure location
- Instead of only one action, they now need to setup wl2 and then use the cli like they do locally making it possible to deploy from their makefile
- They don’t need to use template fill anymore since wl2 cli fills the template when you execute wl2 deploy 

Before it’s merged, you can give it a try replacing the main branch with initial in branch. I gave it a try in my dummy deployment here https://github.com/Jimdo/wonderland2-dummy-deployment/pull/1