### PR TITLE
Add cli version as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ After the setup step, you can use the `wl2` cli as needed. The example shows a d
   with:
     wonderland-github-token: ${{ secrets.WONDERLAND_GITHUB_TOKEN }}
     bastion-key: ${{ secrets.WONDERLAND_SSH_KEY }}
+    cli-version: latest
 
 - name: Deploy to Wonderland 2
   run: wl2 deploy

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   bastion-key:
     description: 'Ssh key for authentication in the bastion host'
     required: true
+  cli-version:
+    required: false
+    description: 'The Wonderland 2 CLI version to use'
+    default: 'latest'
 
 runs:
   using: "composite"
@@ -16,8 +20,10 @@ runs:
         ssh-private-key: ${{ inputs.bastion-key }}
 
     - run: |
+        version=${{ inputs.cli-version }}
+        if [ $version != "latest" ]; then version="tags/${{ inputs.cli-version }}"; fi;
         asset_url=$(curl -s -H "Authorization: token ${{ inputs.wonderland-github-token }}"\
-                    https://api.github.com/repos/Jimdo/wonderland2-cli/releases/latest\
+                    https://api.github.com/repos/Jimdo/wonderland2-cli/releases/$version\
                     | jq -r '.assets[] | select (.name=="wl2-linux-amd64").url')
         curl -sSLfo /usr/local/bin/wl2 -H "Authorization: token ${{ inputs.wonderland-github-token }}" -H "Accept:application/octet-stream" $asset_url
         chmod +x /usr/local/bin/wl2


### PR DESCRIPTION
to allow users to pin the cli version they use.

### How to test

1. Use this setup to configure the action and check that it downloads the latest cli version
```yaml
- name: Configure WL2
   uses: Jimdo/wonderland2-setup-action@add-version-parameter
   with:
     wonderland-github-token: ${{ secrets.WONDERLAND_GITHUB_TOKEN }}
     bastion-key: ${{ secrets.WONDERLAND_SSH_KEY }}
     cli-version: latest
```
2. Use this setup to configure the action and check that it downloads the specific (v0.5.0) cli version 
```yaml
- name: Configure WL2
   uses: Jimdo/wonderland2-setup-action@add-version-parameter
   with:
     wonderland-github-token: ${{ secrets.WONDERLAND_GITHUB_TOKEN }}
     bastion-key: ${{ secrets.WONDERLAND_SSH_KEY }}
     cli-version: v0.5.0
```