### PR TITLE
Force usage of the default WONDERLAND_GITHUB_TOKEN we pull from vault

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,10 @@ runs:
       run: |
         version=${{ inputs.cli-version }}
         if [ $version != "latest" ]; then version="tags/${{ inputs.cli-version }}"; fi;
-        asset_url=$(curl -s -H "Authorization: token ${{ env.WONDERLAND_GITHUB_TOKEN }}"\
+        asset_url=$(curl -s -H "Authorization: token ${{ steps.wl2-secrets.outputs.WONDERLAND_GITHUB_TOKEN }}"\
                     https://api.github.com/repos/Jimdo/wonderland2-cli/releases/$version\
                     | jq -r '.assets[] | select (.name=="wl2-linux-amd64").url')
-        curl -sSLfo /usr/local/bin/wl2 -H "Authorization: token ${{ env.WONDERLAND_GITHUB_TOKEN }}" -H "Accept:application/octet-stream" $asset_url
+        curl -sSLfo /usr/local/bin/wl2 -H "Authorization: token ${{ steps.wl2-secrets.outputs.WONDERLAND_GITHUB_TOKEN }}" -H "Accept:application/octet-stream" $asset_url
         chmod +x /usr/local/bin/wl2
         echo "WL2_ENVIRONMENT=${{ inputs.environment }}" >> $GITHUB_ENV
       shell: bash
@@ -55,7 +55,7 @@ runs:
 
     - name: Start SSH proxy
       run: |
-        GITHUB_USER=$(curl --silent -H 'Authorization: token ${{ env.WONDERLAND_GITHUB_TOKEN }}' https://api.github.com/user | jq -r .login)
+        GITHUB_USER=$(curl --silent -H 'Authorization: token ${{ steps.wl2-secrets.outputs.WONDERLAND_GITHUB_TOKEN }}' https://api.github.com/user | jq -r .login)
         ssh -o StrictHostKeyChecking=no -vTND 8080 $GITHUB_USER@bastion.${{ inputs.environment }}.jimdo.systems &
         kubectl config set-cluster arn:aws:eks:eu-west-1:114104571271:cluster/wl-${{ inputs.environment }}-eu-west-1 --proxy-url=socks5://localhost:8080
       shell: bash


### PR DESCRIPTION
If users provide their own WONDERLAND_GITHUB_TOKEN it takes precedence to the one we supply. Since it's more likely their token doesn't have proper permissions to download the wl2 binary, we switch from using the one on the environment to the one specifically from the step.