### PR TITLE
feat: support macOS runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,12 @@ jobs:
         uses: ./
       - name: Run list
         run: wl2 list
+  test_e2e_macos:
+    runs-on: macos-12
+    concurrency: macos-dummy-deployment
+    steps:
+      - uses: actions/checkout@v1
+      - name: Test Action (default CLI release)
+        uses: ./
+      - name: Run list
+        run: wl2 list

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ runs:
   steps:
     - name: Install AWS CLI
       uses: unfor19/install-aws-cli-action@v1.0.4
+      if: runner.os != 'macOS'
       with:
         version: 2
         verbose: false
@@ -42,10 +43,13 @@ runs:
     - name: Install WL2 cli
       run: |
         version=${{ inputs.cli-version }}
+        runner_os=${{ runner.os }}
+        name=wl2-linux-amd64
+        if [ $runner_os == "macOS" ]; then name="wl2-darwin-amd64"; fi;
         if [ $version != "latest" ]; then version="tags/${{ inputs.cli-version }}"; fi;
         asset_url=$(curl -s -H "Authorization: token ${{ steps.wl2-secrets.outputs.WONDERLAND_GITHUB_TOKEN }}"\
                     https://api.github.com/repos/Jimdo/wonderland2-cli/releases/$version\
-                    | jq -r '.assets[] | select (.name=="wl2-linux-amd64").url')
+                    | jq -r '.assets[] | select (.name=="$name").url')
         mkdir -p $HOME/.local/bin
         curl -sSLfo $HOME/.local/bin/wl2 -H "Authorization: token ${{ steps.wl2-secrets.outputs.WONDERLAND_GITHUB_TOKEN }}" -H "Accept:application/octet-stream" $asset_url
         chmod +x $HOME/.local/bin/wl2


### PR DESCRIPTION
Currently, the wonderland2-setup-action fails on macOS runners because they are not supported by the unfor19/install-aws-cli-action used. The action does not intend to add support: https://github.com/unfor19/install-aws-cli-action/issues/10

However, this step actually should not be necessary on public runners and was only added for internal ones.

Therefore, skip the aws step on macOS and download the correct build.

Paired with @thundering-herd 